### PR TITLE
Fix Bug in Attention for 3D U-Net

### DIFF
--- a/medsegpy/modeling/meta_arch/unet.py
+++ b/medsegpy/modeling/meta_arch/unet.py
@@ -221,6 +221,7 @@ class UNet2D(ModelBuilder):
                 attn_out, attn_coeffs = self._multi_attention_module(
                     in_channels=num_filters[depth_cnt],
                     intermediate_channels=num_filters[depth_cnt],
+                    sub_sample_factor=self._get_pool_size(x_skip),
                 )([x_skip, gating_signal])
                 skip_connect = attn_out
 


### PR DESCRIPTION
## Description
- The current code for attention does not work for 3D images with a depth of 1.
- This is because the default value of `sub_sample_factor` in the `MultiAttentionModule3D` layer is 2 for all dimensions. This will not work if the image has a depth of 1.
- This pull request adds a single line that will set the value of `sub_sample_factor` to be the output of `_get_pool_size()`, which already correctly handles images with a depth of 1.

## Toy Run
### Description
This toy run trains a 3D U-Net on a few examples from the dataset located at `/bmrNAS/people/arjun/data/oai_data/h5_files_whitened_3d/`. Patches of size (384, 384, 4, 1) are inputted into the model. 

The U-Net will have a depth of 4. This will ensure each patch is downsampled to size (96, 96, 1, 128) by the third level of the U-Net, and, as a result, the output of the skip connection for the third level will have a depth of 1 when passed to the `MultiAttentionModule3D` layer.

### Config File
```
MODEL_NAME: "UNet3D"
TAG: "PatchDataLoader"
TRAIN_DATASET: "mini_oai_train"
VAL_DATASET: "mini_oai_val"
TEST_DATASET: "mini_oai_test"
N_EPOCHS: 3
TRAIN_BATCH_SIZE: 5
VALID_BATCH_SIZE: 3
TEST_BATCH_SIZE: 3
CATEGORIES: (0, (1, 2), 3, (4, 5))
IMG_SIZE: (384, 384, 4, 1)
USE_ATTENTION: True
DEPTH: 4
NUM_FILTERS: []
OUTPUT_DIR: "tests/mock_data/results/unet_3d"
```
### Train/Val/Test Split
The "mini_oai" dataset has 6 volumes for training, 2 volumes for validation, and 2 volumes for testing.

### Results
Below are the training and validation loss graphs, visualized in TensorBoard:
<img width="1055" alt="Screen Shot 2020-09-11 at 11 26 23 AM" src="https://user-images.githubusercontent.com/22404404/92948696-c426cb00-f427-11ea-9005-62e1e4b2be0c.png">
<img width="1058" alt="Screen Shot 2020-09-11 at 11 30 30 AM" src="https://user-images.githubusercontent.com/22404404/92948711-cc7f0600-f427-11ea-8658-2263c4edbfc6.png">

### Summary
The training loss decreases over 3 epochs, which indicates the model is successfully training. Since the training set was so small, it is likely the model overfit to the training data. This is probably why the validaton loss increases over the 3 epochs.