### PR TITLE
Adjust formatting for SSL project code

### DIFF
--- a/medsegpy/config.py
+++ b/medsegpy/config.py
@@ -758,7 +758,7 @@ class ContextEncoderConfig(Config):
         super().summary(summary_vars)
 
 
-class ContextUNetConfig(Config):
+class ContextUNetConfig(ContextEncoderConfig):
     """
     Configuration for the ContextUNet model.
 
@@ -769,16 +769,6 @@ class ContextUNetConfig(Config):
     """
 
     MODEL_NAME = "ContextUNet"
-    NUM_FILTERS = [[32, 32], [64, 64], [128, 128], [256, 256]]
-
-    def __init__(self, state="training", create_dirs=True):
-        super().__init__(self.MODEL_NAME, state, create_dirs=create_dirs)
-
-    def summary(self, additional_vars=None):
-        summary_vars = ["NUM_FILTERS"]
-        if additional_vars:
-            summary_vars.extend(additional_vars)
-        super().summary(summary_vars)
 
 
 class ContextInpaintingConfig(ContextUNetConfig):

--- a/medsegpy/cross_validation/cv_util.py
+++ b/medsegpy/cross_validation/cv_util.py
@@ -147,12 +147,9 @@ class CrossValidationProcessor:
 
         for i in range(len(temp)):
             for j in range(i + 1, len(temp)):
-                assert (
-                    len(set(temp[i]) & set(temp[j])) == 0
-                ), "Test bins %d and %d not mutually exclusive - %d overlap" % (
-                    i,
-                    j,
-                    len(set(temp[i]) & set(temp[j])),
+                assert len(set(temp[i]) & set(temp[j])) == 0, (
+                    "Test bins %d and %d not mutually exclusive - %d overlap"
+                    % (i, j, len(set(temp[i]) & set(temp[j])))
                 )
 
         self.num_valid_bins = num_valid_bins

--- a/medsegpy/data/data_utils.py
+++ b/medsegpy/data/data_utils.py
@@ -195,7 +195,7 @@ def generate_poisson_disc_mask(
     x /= x.max()
     y = np.maximum(abs(y - img_shape[-2] / 2), 0)
     y /= y.max()
-    r = np.sqrt(x**2 + y**2)
+    r = np.sqrt(x ** 2 + y ** 2)
 
     # Quick checks
     assert int(num_samples) == num_samples, (

--- a/medsegpy/data/data_utils.py
+++ b/medsegpy/data/data_utils.py
@@ -3,6 +3,7 @@ import warnings
 from typing import Sequence, Union
 
 import numpy as np
+from numba import njit
 
 
 def collect_mask(mask: np.ndarray, index: Sequence[Union[int, Sequence[int], int]]):
@@ -233,6 +234,7 @@ def generate_poisson_disc_mask(
     return mask, patch_mask
 
 
+@njit
 def _poisson(nx, ny, K, R, num_samples=None, patch_size=0.0, seed=None):
     mask = np.zeros((ny, nx))
     patch_mask = np.zeros((ny, nx))

--- a/medsegpy/data/datasets/abct.py
+++ b/medsegpy/data/datasets/abct.py
@@ -153,4 +153,6 @@ def register_all_abct():
             txt_file_or_scan_root = os.path.join(
                 Cluster.working_cluster().data_dir, txt_file_or_scan_root
             )
+        if not os.path.exists(txt_file_or_scan_root):
+            continue
         register_abct(dataset_name, txt_file_or_scan_root)

--- a/medsegpy/data/datasets/oai.py
+++ b/medsegpy/data/datasets/oai.py
@@ -176,4 +176,6 @@ def register_all_oai():
     for dataset_name, scan_root in _DATA_CATALOG.items():
         if not os.path.isabs(scan_root):
             scan_root = os.path.join(Cluster.working_cluster().data_dir, scan_root)
+        if not os.path.exists(scan_root):
+            continue
         register_oai(dataset_name, scan_root)

--- a/medsegpy/data/datasets/qdess_mri.py
+++ b/medsegpy/data/datasets/qdess_mri.py
@@ -162,6 +162,7 @@ def load_2d_from_filepaths(filepaths: list, source_path: str, dataset_name: str 
                     corresponding ground truth segmentations.
         total_num_slices: The total number of slices for this dataset.
         dataset_name: The name of the dataset.
+
     Returns:
         dataset_dicts: A list of dictionaries, described above in the
                         docstring.

--- a/medsegpy/data/datasets/qdess_mri.py
+++ b/medsegpy/data/datasets/qdess_mri.py
@@ -4,6 +4,7 @@ import os
 import re
 
 from medsegpy.data.catalog import DatasetCatalog, MetadataCatalog
+from medsegpy.utils.cluster import Cluster
 
 logger = logging.getLogger(__name__)
 
@@ -336,4 +337,8 @@ def register_all_qdess_datasets():
     Registers all qDESS MRI datasets listed in _DATA_CATALOG.
     """
     for dataset_name, scan_root in _DATA_CATALOG.items():
+        if not os.path.isabs(scan_root):
+            scan_root = os.path.join(Cluster.working_cluster().data_dir, scan_root)
+        if not os.path.exists(scan_root):
+            continue
         register_qdess_dataset(scan_root=scan_root, dataset_name=dataset_name)

--- a/medsegpy/data/im_gens.py
+++ b/medsegpy/data/im_gens.py
@@ -1234,11 +1234,9 @@ class OAI3DBlockGenerator(OAI3DGenerator):
         # this means shape of total volume must be perfectly divisible into
         # cubes of size IMG_SIZE
         for dim in range(3):
-            assert (
-                total_volume_shape[dim] % self.config.IMG_SIZE[dim] == 0
-            ), "Cannot divide volume of size %s to blocks of size %s" % (
-                total_volume_shape,
-                self.config.IMG_SIZE,
+            assert total_volume_shape[dim] % self.config.IMG_SIZE[dim] == 0, (
+                "Cannot divide volume of size %s to blocks of size %s"
+                % (total_volume_shape, self.config.IMG_SIZE)
             )
 
     def img_generator_test(self, model=None):

--- a/medsegpy/data/transforms/transform.py
+++ b/medsegpy/data/transforms/transform.py
@@ -67,6 +67,7 @@ class MedTransform(ABC):
             img (ndarray): of shape NxHxWxC, or HxWxC or HxW. The array can be
                 of type uint8 in range [0, 255], or floating point in range
                 [0, 1] or [0, 255].
+
         Returns:
             ndarray: image after apply the transformation.
         """
@@ -147,6 +148,7 @@ class TransformList:
         Args:
             x: input to apply the transform operations.
             meth (str): meth.
+
         Returns:
             x: after apply the transformation.
         """
@@ -167,6 +169,7 @@ class TransformList:
         """
         Args:
             other (TransformList): transformation to add.
+
         Returns:
             TransformList: list of transforms.
         """
@@ -177,6 +180,7 @@ class TransformList:
         """
         Args:
             other (TransformList): transformation to add.
+
         Returns:
             TransformList: list of transforms.
         """
@@ -188,6 +192,7 @@ class TransformList:
         """
         Args:
             other (TransformList): transformation to add.
+
         Returns:
             TransformList: list of transforms.
         """

--- a/medsegpy/data/transforms/transform_gen.py
+++ b/medsegpy/data/transforms/transform_gen.py
@@ -220,20 +220,20 @@ class CoarseDropout(TransformGen):
             max_height: The maximum height of each hole.
             max_width: The maximum width of each hole.
             min_holes: The minimum number of holes to drop out.
-                            If None, the maximum number of holes will
-                        be dropped out.
+                If None, the maximum number of holes will
+                be dropped out.
             min_height: The minimum height of each hole.
-                            If None, each hole will have maximum height.
+                If None, each hole will have maximum height.
             min_width: The minimum width of each hole.
-                            If None, each hole will have maximum width.
+                If None, each hole will have maximum width.
             img_shape: The height and width of each image.
             max_perc_area_to_remove: The maximum fraction of the image that
-                                    will be removed and filled with a constant
-                                    value. This is useful to prevent too
-                                    much of the image from being modified.
+                will be removed and filled with a constant
+                value. This is useful to prevent too
+                much of the image from being modified.
             fill_value: The value used to fill in each hole.
             sampling_pattern: The type of sampling pattern to use when
-                                selecting random patches.
+                selecting random patches.
                 Possible values: "uniform", "poisson"
             num_precompute: The number of masks to precompute.
         """
@@ -249,9 +249,8 @@ class CoarseDropout(TransformGen):
         # Precompute masks
         self.precomputed_masks = []
         if sampling_pattern == "poisson":
-            assert min_height == max_height == min_width == max_width, (
-                "Only square patches are allowed if sampling pattern is " "'poisson'"
-            )
+            if not (min_height == max_height == min_width == max_width):
+                raise ValueError("Only square patches are allowed if sampling pattern is 'poisson'")
 
             hole_size = min_width
             # Check max_perc_area_to_remove
@@ -336,7 +335,8 @@ class CoarseDropout(TransformGen):
 
         Args:
             img: A N x H x W x C image, containing N images with height H,
-                    width W, and consisting of C channels.
+                width W, and consisting of C channels.
+
         Returns:
             An instance of the MedTransform "FillRegionsWithValue",
                 initialized with the appropriate parameters based on the
@@ -425,7 +425,7 @@ class SwapPatches(TransformGen):
             min_height = max_height
         if not is_square:
             if max_width is None:
-                raise ValueError("Value of 'max_width' must not be None if patch is " "not square")
+                raise ValueError("Value of 'max_width' must not be None if patch is 'not square'")
             if min_width is None:
                 min_width = max_width
         self._init(locals())
@@ -437,7 +437,7 @@ class SwapPatches(TransformGen):
                 f"If sampling_pattern is 'poisson', min_height (= {min_height}) "
                 f"must equal max_height (= {max_height})"
             )
-            assert is_square, "Only square patches are allowed if sampling pattern is " "'poisson'"
+            assert is_square, "Only square patches are allowed if sampling pattern is 'poisson'"
 
             patch_size = max_height
             # Check max_perc_area_to_modify
@@ -545,6 +545,7 @@ class SwapPatches(TransformGen):
         Args:
             img: A N x H x W x C image, containing N images with height H,
                     width W, and consisting of C channels.
+
         Returns:
             An instance of the MedTransform "Swap2DPatches",
                 initialized with the appropriate parameters based on the

--- a/medsegpy/data/transforms/transform_gen.py
+++ b/medsegpy/data/transforms/transform_gen.py
@@ -52,10 +52,9 @@ def check_dtype(img: np.ndarray):
     assert isinstance(img, np.ndarray), "[TransformGen] Needs an numpy array, but got a {}!".format(
         type(img)
     )
-    assert (
-        not isinstance(img.dtype, np.integer) or img.dtype == np.uint8
-    ), "[TransformGen] Got image of type {}, " "use uint8 or floating points instead!".format(
-        img.dtype
+    assert not isinstance(img.dtype, np.integer) or img.dtype == np.uint8, (
+        "[TransformGen] Got image of type {}, "
+        "use uint8 or floating points instead!".format(img.dtype)
     )
     assert img.ndim > 2, img.ndim
 
@@ -262,9 +261,9 @@ class CoarseDropout(TransformGen):
             #       Max packing density when using hexagonal packing is
             #       pi / (2 * sqrt(3))
             max_pos_area = (img_shape[0] * img_shape[1]) * (np.pi / (2 * np.sqrt(3)))
-            max_num_patches = max_pos_area // ((np.pi / 2) * (hole_size**2))
+            max_num_patches = max_pos_area // ((np.pi / 2) * (hole_size ** 2))
             max_pos_perc_area = np.round(
-                (max_num_patches * (hole_size**2)) / (img_shape[0] * img_shape[1]), decimals=3
+                (max_num_patches * (hole_size ** 2)) / (img_shape[0] * img_shape[1]), decimals=3
             )
             if max_perc_area_to_remove >= max_pos_perc_area:
                 raise ValueError(
@@ -279,7 +278,7 @@ class CoarseDropout(TransformGen):
             # If `sampling_pattern` is "poisson", precompute
             # `num_precompute` masks
             num_samples = ((img_shape[0] * img_shape[1]) * max_perc_area_to_remove) // (
-                hole_size**2
+                hole_size ** 2
             )
             logger.info("Precomputing masks...")
             for _ in tqdm.tqdm(range(num_precompute)):
@@ -448,9 +447,9 @@ class SwapPatches(TransformGen):
             #       Max packing density when using hexagonal packing is
             #       pi / (2 * sqrt(3))
             max_pos_area = (img_shape[0] * img_shape[1]) * (np.pi / (2 * np.sqrt(3)))
-            max_num_patches = max_pos_area // ((np.pi / 2) * (patch_size**2))
+            max_num_patches = max_pos_area // ((np.pi / 2) * (patch_size ** 2))
             max_pos_perc_area = np.round(
-                (max_num_patches * (patch_size**2)) / (img_shape[0] * img_shape[1]), decimals=3
+                (max_num_patches * (patch_size ** 2)) / (img_shape[0] * img_shape[1]), decimals=3
             )
             if max_perc_area_to_modify >= max_pos_perc_area:
                 raise ValueError(
@@ -465,7 +464,7 @@ class SwapPatches(TransformGen):
             # If `sampling_pattern` is "poisson", precompute
             # `num_precompute` masks
             num_samples = ((img_shape[0] * img_shape[1]) * max_perc_area_to_modify) // (
-                patch_size**2
+                patch_size ** 2
             )
             assert num_samples >= 2, f"Number of samples (= {num_samples}) must be >= 2"
             # Ensure number of samples is even
@@ -664,10 +663,9 @@ def apply_transform_gens(
     tfms = []
     for g in transform_gens:
         tfm = g.get_transform(img) if isinstance(g, TransformGen) else g
-        assert isinstance(
-            tfm, MedTransform
-        ), "TransformGen {} must return an instance of MedTransform! " "Got {} instead".format(
-            g, tfm
+        assert isinstance(tfm, MedTransform), (
+            "TransformGen {} must return an instance of MedTransform! "
+            "Got {} instead".format(g, tfm)
         )
         img = tfm.apply_image(img)
         tfms.append(tfm)

--- a/medsegpy/evaluation/metrics.py
+++ b/medsegpy/evaluation/metrics.py
@@ -69,7 +69,7 @@ def rms_cv(y_pred: np.ndarray, y_true: np.ndarray, dim=None):
     stds = np.std([y_pred, y_true], axis=0)
     means = np.mean([y_pred, y_true], axis=0)
     cv = stds / means
-    return np.sqrt(np.mean(cv**2, axis=dim))
+    return np.sqrt(np.mean(cv ** 2, axis=dim))
 
 
 def rmse_cv(y_pred: np.ndarray, y_true: np.ndarray, dim=None):

--- a/medsegpy/modeling/deeplab_2d/deeplab_model.py
+++ b/medsegpy/modeling/deeplab_2d/deeplab_model.py
@@ -733,6 +733,7 @@ class DeeplabModel:
         """Preprocesses a numpy array encoding a batch of images.
         # Arguments
             x: a 4D numpy array consists of RGB values within [0, 255].
+
         # Returns
             Input array scaled to [-1.,1.]
         """

--- a/medsegpy/modeling/layers/convolutional.py
+++ b/medsegpy/modeling/layers/convolutional.py
@@ -86,3 +86,8 @@ class ConvStandardized2D(Conv2D):
         if self.activation is not None:
             return self.activation(outputs)
         return outputs
+
+
+# Add aliases for class
+ConvWeightStandardization2D = ConvStandardized2D
+ConvWS2D = ConvStandardized2D

--- a/medsegpy/modeling/loading.py
+++ b/medsegpy/modeling/loading.py
@@ -18,8 +18,10 @@ def model_from_config(config, custom_objects=None):
       custom_objects: Optional dictionary mapping names
           (strings) to custom classes or functions to be
           considered during deserialization.
+
     Returns:
       A Keras model instance (uncompiled).
+
     Raises:
       TypeError: if `config` is not a dictionary.
     """
@@ -41,8 +43,10 @@ def model_from_yaml(yaml_string, custom_objects=None):
       custom_objects: Optional dictionary mapping names
           (strings) to custom classes or functions to be
           considered during deserialization.
+
     Returns:
       A Keras model instance (uncompiled).
+
     Raises:
       ImportError: if yaml module is not found.
     """
@@ -61,6 +65,7 @@ def model_from_json(json_string, custom_objects=None):
       custom_objects: Optional dictionary mapping names
           (strings) to custom classes or functions to be
           considered during deserialization.
+
     Returns:
       A Keras model instance (uncompiled).
     """

--- a/medsegpy/modeling/meta_arch/inpainting_and_seg_unet.py
+++ b/medsegpy/modeling/meta_arch/inpainting_and_seg_unet.py
@@ -83,8 +83,10 @@ class ContextEncoder(ModelBuilder):
         Builds the encoder network and returns the resulting model.
         This implementation will overload the abstract method defined in the
         superclass "ModelBuilder".
+
         Args:
             input_tensor: The input to the network.
+
         Returns:
             model: A Model that defines the encoder network.
         """
@@ -145,6 +147,7 @@ class ContextEncoder(ModelBuilder):
         Builds one block of the ContextEncoder.
         Each block consists of the following structure:
         [Conv -> Activation] -> BN -> Dropout.
+
         Args:
             x: Input tensor.
             num_filters: Number of filters to use for each conv layer.
@@ -153,6 +156,7 @@ class ContextEncoder(ModelBuilder):
             kernel_initializer: Kernel initializer accepted by
                                 `keras.layers.Conv(...)`.
             dropout: Dropout rate.
+
         Returns:
             Output of encoder block.
         """
@@ -195,8 +199,10 @@ class ContextEncoder(ModelBuilder):
     def _build_input(input_size: Tuple):
         """
         Creates an input tensor of size "input_size".
+
         Args:
             input_size: The size of the input tensor for the model.
+
         Returns:
             A symbolic input (i.e. a placeholder) with size "input_size".
         """
@@ -211,8 +217,10 @@ class ContextEncoder(ModelBuilder):
         """
         Determines the right size of the pooling filter based on the
         dimensions of the input tensor `x`.
+
         Args:
             x: The input tensor.
+
         Returns:
             A list with the same number of elements as dimensions of `x`,
             where each element is either 2 or 3.
@@ -281,8 +289,10 @@ class ContextUNet(ModelBuilder):
         resulting model.
         This implementation will overload the abstract method defined in the
         superclass "ModelBuilder".
+
         Args:
             input_tensor: The input to the network.
+
         Returns:
             model: A Model that defines the full encoder/decoder architecture.
         """
@@ -379,6 +389,7 @@ class ContextUNet(ModelBuilder):
         Each block of the decoder will have the following structure:
         Input -> Transposed Convolution -> Concatenate Skip Connection
         -> Convolution -> BN -> Dropout (optional)
+
         Args:
             x: Input tensor.
             x_skip: The output of the next highest layer of the
@@ -397,6 +408,7 @@ class ContextUNet(ModelBuilder):
                                     convolutional and regular convolutional
                                     layers.
             dropout: Dropout rate.
+
         Returns:
            Output of the decoder block.
         """
@@ -450,8 +462,10 @@ class ContextUNet(ModelBuilder):
     def _build_input(input_size: Tuple):
         """
         Creates an input tensor of size "input_size".
+
         Args:
             input_size: The size of the input tensor for the model.
+
         Returns:
             A symbolic input (i.e. a placeholder) with size "input_size".
         """

--- a/medsegpy/modeling/meta_arch/unet.py
+++ b/medsegpy/modeling/meta_arch/unet.py
@@ -154,7 +154,7 @@ class UNet2D(ModelBuilder):
         num_classes = cfg.get_num_classes()
         num_filters = cfg.NUM_FILTERS
         if not num_filters:
-            num_filters = [2**feat * 32 for feat in range(depth)]
+            num_filters = [2 ** feat * 32 for feat in range(depth)]
         else:
             depth = len(num_filters)
 

--- a/medsegpy/modeling/unet_2d/anisotropic_unet_model.py
+++ b/medsegpy/modeling/unet_2d/anisotropic_unet_model.py
@@ -38,7 +38,7 @@ def anisotropic_unet_2d(
         raise ValueError("input_size must be a tuple of size (height, width, 1)")
 
     if num_filters is None:
-        nfeatures = [2**feat * 32 for feat in np.arange(depth)]
+        nfeatures = [2 ** feat * 32 for feat in np.arange(depth)]
     else:
         nfeatures = num_filters
         assert len(nfeatures) == depth

--- a/medsegpy/modeling/unet_2d/residual_unet_model.py
+++ b/medsegpy/modeling/unet_2d/residual_unet_model.py
@@ -143,7 +143,7 @@ def residual_unet_2d(
         raise ValueError("input_size must be a tuple of size (height, width, 1)")
 
     if num_filters is None:
-        nfeatures = [2**feat * 32 for feat in np.arange(depth)]
+        nfeatures = [2 ** feat * 32 for feat in np.arange(depth)]
     else:
         nfeatures = num_filters
         assert len(nfeatures) == depth

--- a/medsegpy/modeling/unet_2d/unet_model.py
+++ b/medsegpy/modeling/unet_2d/unet_model.py
@@ -53,7 +53,7 @@ def unet_2d_model(input_size=DEFAULT_INPUT_SIZE, input_tensor=None, output_mode=
     if input_tensor is None and (type(input_size) is not tuple or len(input_size) != 3):
         raise ValueError("input_size must be a tuple of size (height, width, 1)")
 
-    nfeatures = [2**feat * 32 for feat in np.arange(6)]
+    nfeatures = [2 ** feat * 32 for feat in np.arange(6)]
     depth = len(nfeatures)
 
     conv_ptr = []
@@ -182,7 +182,7 @@ def unet_2d_model_v2(
         raise ValueError("input_size must be a tuple of size (height, width, 1)")
 
     if num_filters is None:
-        nfeatures = [2**feat * 32 for feat in np.arange(depth)]
+        nfeatures = [2 ** feat * 32 for feat in np.arange(depth)]
     else:
         nfeatures = num_filters
         assert len(nfeatures) == depth

--- a/medsegpy/modeling/unet_3d_model.py
+++ b/medsegpy/modeling/unet_3d_model.py
@@ -32,7 +32,7 @@ def unet_3d_model(
         raise ValueError("input_size must be a tuple of size (height, width, slices, 1)")
 
     if num_filters is None:
-        nfeatures = [2**feat * 32 for feat in np.arange(depth)]
+        nfeatures = [2 ** feat * 32 for feat in np.arange(depth)]
     else:
         nfeatures = num_filters
         assert len(nfeatures) == depth

--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,7 @@ def get_required_packages():
         "pandas",
         "medpy",
         "numpy",
+        "numba",
         "h5py",
         "natsort",
         "scipy",


### PR DESCRIPTION
This PR continues PR #35. I adjusted some formatting issues brought up in the previous PR.

The overall changes are:

- Ran `make autoformat` & adjusted some docstring formatting issues and indentation errors
- Made ContextUNetConfig a subclass of ContextEncoderConfig
- Added the `@njit` decorator to the function that does Poisson-disc sampling
- Ensured datasets are only registered if their paths exist
- Added aliases for `ConvStandardized2D` class
- Split if/else blocks in __init__() for `CoarseDropout` and `SwapPatches` into separate instance methods